### PR TITLE
Refactor to accept plan model in subscription builder to prevent hard-coded subscription amount

### DIFF
--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Veeqtoh\Cashier\Concerns;
 
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Unicodeveloper\Paystack\Facades\Paystack;
 use Veeqtoh\Cashier\Classes\SubscriptionBuilder;
@@ -17,7 +18,7 @@ trait ManagesSubscriptions
     /**
      * Begin creating a new subscription.
      */
-    public function newSubscription(string $plan, string $subscription = 'default'): SubscriptionBuilder
+    public function newSubscription(Model $plan, string $subscription = 'default'): SubscriptionBuilder
     {
         return new SubscriptionBuilder($this, $plan, $subscription);
     }


### PR DESCRIPTION
### Motivation and Context ###
This change addressed an identified bug where an hard-coded ammount is passed on for a new subscription. We have now passed on the plan model and can grab the ammount from this object dynamically.

### Dependencies ###
N/A

### Test Instructions ###
N/A